### PR TITLE
chores and performance boost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["statistics", "stream"]
 exclude = [".github", ".pre-commit-config.yaml"]
 readme = "README.md"
 [dependencies]
-num = "0.4.0"
-ordered-float = { version = "3.0", features = ["serde"] }
+num = "0.4"
+ordered-float = { version = "3.9", features = ["serde"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -17,17 +17,19 @@ use crate::sum::Sum;
 use crate::variance::Variance;
 
 #[doc(hidden)]
-pub struct IterStat<I>
+pub struct IterStat<U, I>
 where
+    U: Univariate<I::Item>,
     I: Iterator,
     I::Item: Float + FromPrimitive + AddAssign + SubAssign + 'static,
 {
-    stat: Box<dyn Univariate<I::Item>>,
+    stat: U,
     underlying: I,
 }
 
-impl<I> Iterator for IterStat<I>
+impl<U, I> Iterator for IterStat<U, I>
 where
+    U: Univariate<I::Item>,
     I: Iterator,
     I::Item: Float + FromPrimitive + AddAssign + SubAssign,
 {
@@ -55,13 +57,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_sum(self) -> IterStat<Self>
+    fn online_sum(self) -> IterStat<Sum<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Sum::new()),
+            stat: Sum::new(),
             underlying: self,
         }
     }
@@ -77,13 +79,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_mean(self) -> IterStat<Self>
+    fn online_mean(self) -> IterStat<Mean<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Mean::new()),
+            stat: Mean::new(),
             underlying: self,
         }
     }
@@ -99,13 +101,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_count(self) -> IterStat<Self>
+    fn online_count(self) -> IterStat<Count<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Count::new()),
+            stat: Count::new(),
             underlying: self,
         }
     }
@@ -124,13 +126,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_ewmean(self, alpha: Self::Item) -> IterStat<Self>
+    fn online_ewmean(self, alpha: Self::Item) -> IterStat<EWMean<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(EWMean::new(alpha)),
+            stat: EWMean::new(alpha),
             underlying: self,
         }
     }
@@ -148,13 +150,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_ewvar(self, alpha: Self::Item) -> IterStat<Self>
+    fn online_ewvar(self, alpha: Self::Item) -> IterStat<EWVariance<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(EWVariance::new(alpha)),
+            stat: EWVariance::new(alpha),
             underlying: self,
         }
     }
@@ -173,13 +175,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_iqr(self, q_inf: Self::Item, q_sup: Self::Item) -> IterStat<Self>
+    fn online_iqr(self, q_inf: Self::Item, q_sup: Self::Item) -> IterStat<IQR<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(IQR::new(q_inf, q_sup).expect("q_inf must be strictly less than q_sup")),
+            stat: IQR::new(q_inf, q_sup).expect("q_inf must be strictly less than q_sup"),
             underlying: self,
         }
     }
@@ -197,13 +199,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_kurtosis(self, bias: bool) -> IterStat<Self>
+    fn online_kurtosis(self, bias: bool) -> IterStat<Kurtosis<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Kurtosis::new(bias)),
+            stat: Kurtosis::new(bias),
             underlying: self,
         }
     }
@@ -219,13 +221,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_max(self) -> IterStat<Self>
+    fn online_max(self) -> IterStat<Max<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Max::new()),
+            stat: Max::new(),
             underlying: self,
         }
     }
@@ -241,13 +243,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_abs_max(self) -> IterStat<Self>
+    fn online_abs_max(self) -> IterStat<AbsMax<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(AbsMax::new()),
+            stat: AbsMax::new(),
             underlying: self,
         }
     }
@@ -263,13 +265,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_min(self) -> IterStat<Self>
+    fn online_min(self) -> IterStat<Min<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Min::new()),
+            stat: Min::new(),
             underlying: self,
         }
     }
@@ -285,13 +287,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_ptp(self) -> IterStat<Self>
+    fn online_ptp(self) -> IterStat<PeakToPeak<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(PeakToPeak::new()),
+            stat: PeakToPeak::new(),
             underlying: self,
         }
     }
@@ -312,13 +314,13 @@ pub trait IterStatisticsExtend: Iterator {
     ///     assert_eq!(d, t);
     /// }
     /// ```
-    fn online_quantile(self, q: Self::Item) -> IterStat<Self>
+    fn online_quantile(self, q: Self::Item) -> IterStat<Quantile<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Quantile::new(q).expect("q should be betweek 0 and 1")),
+            stat: Quantile::new(q).expect("q should be between 0 and 1"),
             underlying: self,
         }
     }
@@ -336,13 +338,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_skew(self, bias: bool) -> IterStat<Self>
+    fn online_skew(self, bias: bool) -> IterStat<Skew<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Skew::new(bias)),
+            stat: Skew::new(bias),
             underlying: self,
         }
     }
@@ -360,13 +362,13 @@ pub trait IterStatisticsExtend: Iterator {
     /// }
     ///
     /// ```
-    fn online_var(self, ddof: u32) -> IterStat<Self>
+    fn online_var(self, ddof: u32) -> IterStat<Variance<Self::Item>, Self>
     where
         Self::Item: Float + FromPrimitive + AddAssign + SubAssign,
         Self: Sized,
     {
         IterStat {
-            stat: Box::new(Variance::new(ddof)),
+            stat: Variance::new(ddof),
             underlying: self,
         }
     }

--- a/src/mean.rs
+++ b/src/mean.rs
@@ -59,10 +59,7 @@ impl<F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Mean<F>
 
 impl<F: Float + FromPrimitive + AddAssign + SubAssign> Revertable<F> for Mean<F> {
     fn revert(&mut self, x: F) -> Result<(), &'static str> {
-        match self.n.revert(x) {
-            Ok(it) => it,
-            Err(err) => return Err(err),
-        };
+        self.n.revert(x)?;
 
         let count = self.n.get();
         if count == F::from_f64(0.).unwrap() {

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -21,9 +21,9 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(running_quantile.get(), 5.0);
 /// ```
 /// # References
-/// [^1]: [The P² Algorithm for Dynamic Univariateal Computing Calculation of Quantiles and Editor Histograms Without Storing Observations](https://www.cse.wustl.edu/~jain/papers/ftp/psqr.pdf)
+/// [^1]: [The P² Algorithm for Dynamic Calculation of Quantiles and Histograms Without Storing Observations](https://www.cse.wustl.edu/~jain/papers/ftp/psqr.pdf)
 ///
-/// [^2]: [P² quantile estimator: estimating the median without storing values](https://aakinshin.net/posts/p2-quantile-estimator/)
+/// [^2]: [P² quantile estimator: estimating the median without storing values](https://aakinshin.net/posts/p2-quantile-estimator-intro/)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Quantile<F: Float + FromPrimitive + AddAssign + SubAssign> {
     q: F,

--- a/src/rolling.rs
+++ b/src/rolling.rs
@@ -22,43 +22,52 @@ use std::{
 /// let data = vec![9.,7.,3.,2.,6.,1., 8., 5., 4.];
 /// let mut running_sum: Sum<f64> = Sum::new();
 /// // We wrap `running_sum` inside the `Rolling` struct.
-/// let mut rolling_sum: Rolling<f64> = Rolling::new(& mut running_sum, 2).unwrap();
+/// let mut rolling_sum: Rolling<_, f64> = Rolling::new(& mut running_sum, 2).unwrap();
 /// for x in data.iter(){
 ///     rolling_sum.update(*x as f64);
 /// }
 /// assert_eq!(rolling_sum.get(), 9.0);
 /// ```
-
-pub struct Rolling<'a, F: Float + FromPrimitive + AddAssign + SubAssign> {
-    to_roll: &'a mut dyn RollableUnivariate<F>,
+pub struct Rolling<'a, U, F>
+where
+    U: RollableUnivariate<F>,  // Optimization: Generic over U (the concrete type) instead of dyn for static dispatch
+    F: Float + FromPrimitive + AddAssign + SubAssign,
+{
+    to_roll: &'a mut U,  // Optimization: &mut U instead of &mut dyn
     window_size: usize,
     window: VecDeque<F>,
 }
 
-impl<'a, F: Float + FromPrimitive + AddAssign + SubAssign> Rolling<'a, F> {
-    pub fn new(
-        to_roll: &'a mut dyn RollableUnivariate<F>,
-        window_size: usize,
-    ) -> Result<Self, &str> {
+impl<'a, U, F> Rolling<'a, U, F>
+where
+    U: RollableUnivariate<F>,
+    F: Float + FromPrimitive + AddAssign + SubAssign,
+{
+    pub fn new(to_roll: &'a mut U, window_size: usize) -> Result<Self, &'static str> {  // Optimization: &'static str for error (clearer, no lifetime tie)
         if window_size == 0 {
             return Err("Window size should not equals to 0");
         }
         Ok(Self {
             to_roll,
             window_size,
-            window: VecDeque::new(),
+            window: VecDeque::with_capacity(window_size),  // Optimization: Preallocate to avoid reallocs during growth
         })
     }
 }
 
-impl<'a, F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Rolling<'_, F> {
+impl<'a, U, F> Univariate<F> for Rolling<'a, U, F>
+where
+    U: RollableUnivariate<F>,
+    F: Float + FromPrimitive + AddAssign + SubAssign,
+{
     fn update(&mut self, x: F) {
         if self.window.len() == self.window_size {
             // To handle the error, the program panics because returning the error type would change
             // the interface of the get method. This problem is unlikely to happen because we
             // control the size of the sliding window in the constructor.
-            match self.to_roll.revert(*self.window.front().unwrap()) {
-                Ok(it) => it,
+            let oldest = self.window.front().copied().expect("Window should not be empty");  // Optimization: copied() for clarity/safety (F is Copy-like for floats); expect for debug assert
+            match self.to_roll.revert(oldest) {
+                Ok(()) => (),  // Assume revert returns Result<(), _>; adjust if different
                 Err(err) => panic!("{}", err),
             };
             self.window.pop_front();
@@ -73,6 +82,7 @@ impl<'a, F: Float + FromPrimitive + AddAssign + SubAssign> Univariate<F> for Rol
         self.to_roll.get()
     }
 }
+
 mod tests {
     #[test]
     fn it_works() {
@@ -82,7 +92,7 @@ mod tests {
         let data = vec![9., 7., 3., 2., 6., 1., 8., 5., 4.];
         let mut running_var: Variance<f64> = Variance::default();
         // We wrap `running_var` inside the `Rolling` struct.
-        let mut rolling_var: Rolling<f64> = Rolling::new(&mut running_var, 2).unwrap();
+        let mut rolling_var: Rolling<_, f64> = Rolling::new(&mut running_var, 2).unwrap();  // Note: _ for type inference
         for x in data.iter() {
             rolling_var.update(*x as f64);
         }

--- a/src/rolling.rs
+++ b/src/rolling.rs
@@ -22,7 +22,7 @@ use std::{
 /// let data = vec![9.,7.,3.,2.,6.,1., 8., 5., 4.];
 /// let mut running_sum: Sum<f64> = Sum::new();
 /// // We wrap `running_sum` inside the `Rolling` struct.
-/// let mut rolling_sum: Rolling<_, f64> = Rolling::new(& mut running_sum, 2).unwrap();
+/// let mut rolling_sum: Rolling<_, f64> = Rolling::new(&mut running_sum, 2).unwrap();
 /// for x in data.iter(){
 ///     rolling_sum.update(*x as f64);
 /// }
@@ -45,7 +45,7 @@ where
 {
     pub fn new(to_roll: &'a mut U, window_size: usize) -> Result<Self, &'static str> {  // Optimization: &'static str for error (clearer, no lifetime tie)
         if window_size == 0 {
-            return Err("Window size should not equals to 0");
+            return Err("Window size should not equal to 0");
         }
         Ok(Self {
             to_roll,


### PR DESCRIPTION
chores:
* update crates
* fix typos
* make clippy happy
* update info link

perf:
* Static Dispatch: By making Rolling<'a, U, F> generic over U: RollableUnivariate<F>, method calls (update, revert, get) use static dispatch (monomorphized code) instead of dynamic (vtable)
* Same Static Dispatch technique for iter.